### PR TITLE
Param --since

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ Help
       -V, --version                              output the version number
       -d, --max-commit-diff [max-commit-diff]    maximum difference in minutes between commits counted to one session. Default: 120
       -a, --first-commit-add [first-commit-add]  how many minutes first commit of session should add to total. Default: 120
+      -s, --since [since-certain-date]           Analyze data since certain date. [always|yesterday|tonight|lastweek|yyyy-mm-dd] Default: always'
 
     Examples:
 
@@ -115,6 +116,14 @@ Help
      - Estimate hours in repository where developer works 5 hours before first commit in day
 
          $ git hours --first-commit-add 300
+
+     - Estimate hours work in repository since yesterday
+
+       $ git hours --since yesterday
+
+     - Estimate hours work in repository since 2015-01-31
+
+       $ git hours --since 2015-01-31
 
     For more details, visit https://github.com/kimmobrunfeldt/git-hours
 

--- a/index.js
+++ b/index.js
@@ -85,8 +85,8 @@ function parseArgs() {
             int
         )
         .option(
-            '-s, --since [Since date to analyze]',
-            'Since date to start count hours. [always|yesterday|tonight|lastweek|yyyy-mm-dd] Default: ' + config.since,
+            '-s, --since [since-certain-date]',
+            'Analyze data since certain date. [always|yesterday|tonight|lastweek|yyyy-mm-dd] Default: ' + config.since,
             String
         );
 

--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function parseArgs() {
         )
         .option(
             '-s, --since [Since date to analyze]',
-            'Since date to start count hours. Default: ' + config.since,
+            'Since date to start count hours. [always|yesterday|tonight|lastweek|yyyy-mm-dd] Default: ' + config.since,
             String
         );
 
@@ -104,6 +104,14 @@ function parseArgs() {
         console.log('   - Estimate hours in repository where developer works 5 hours before first commit in day');
         console.log('');
         console.log('       $ git hours --first-commit-add 300');
+        console.log('');
+        console.log('   - Estimate hours work in repository since yesterday');
+        console.log('');
+        console.log('       $ git hours --since yesterday');
+        console.log('');
+        console.log('   - Estimate hours work in repository since 2015-01-31');
+        console.log('');
+        console.log('       $ git hours --since 2015-01-31');
         console.log('');
         console.log('  For more details, visit https://github.com/kimmobrunfeldt/git-hours');
         console.log('');

--- a/index.js
+++ b/index.js
@@ -15,12 +15,17 @@ var config = {
     maxCommitDiffInMinutes: 2 * 60,
 
     // How many minutes should be added for the first commit of coding session
-    firstCommitAdditionInMinutes: 2 * 60
+    firstCommitAdditionInMinutes: 2 * 60,
+
+    //Since data
+    since: '2015-01-01'
 };
 
 function main() {
     parseArgs();
     config = mergeDefaultsWithArgs(config);
+
+    console.log(config.since);
 
     commits('.').then(function(commits) {
         var commitsByEmail = _.groupBy(commits, function(commit) {
@@ -79,6 +84,11 @@ function parseArgs() {
             '-a, --first-commit-add [first-commit-add]',
             'how many minutes first commit of session should add to total. Default: ' + config.firstCommitAdditionInMinutes,
             int
+        )
+        .option(
+            '-s, --since [Since date to analyze]',
+            'Since date to start count hours. Default: ' + config.since,
+            String
         );
 
     program.on('--help', function() {
@@ -107,7 +117,8 @@ function mergeDefaultsWithArgs(config) {
     return {
         range: program.range,
         maxCommitDiffInMinutes: program.maxCommitDiff || config.maxCommitDiffInMinutes,
-        firstCommitAdditionInMinutes: program.firstCommitAdd || config.firstCommitAdditionInMinutes
+        firstCommitAdditionInMinutes: program.firstCommitAdd || config.firstCommitAdditionInMinutes,
+        since: program.since || config.since
     };
 }
 
@@ -157,6 +168,7 @@ function commits(gitPath) {
         .reduce(function(allCommits, branchCommits) {
             _.each(branchCommits, function(commit) {
                 allCommits.push(commit);
+                console.log(commit.date);
             });
 
             return allCommits;
@@ -227,7 +239,10 @@ function getBranchCommits(branchLatestCommit) {
                 author: author
             };
 
-            commits.push(commitData);
+            var sinceDate = new Date(config.since);
+            if(commitData.date > sinceDate){
+              commits.push(commitData);
+            }
         });
 
         history.on('end', function() {

--- a/index.js
+++ b/index.js
@@ -121,33 +121,33 @@ function parseArgs() {
 }
 
 function parseSinceDate(options){
-  var justNow, thisPeriod, paramDate;
-  switch(options.since){
-    case 'tonight':
-      justNow = new Date();
-      thisPeriod = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate());
-      config.since = thisPeriod;
-      break;
-    case 'yesterday':
-      justNow = new Date();
-      thisPeriod = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-1);
-      config.since = thisPeriod;
-      break;
-    case 'lastweek':
-      justNow = new Date();
-      thisPeriod = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-7);
-      config.since = thisPeriod;
-      break;
-    case 'always':
-      break;
-    default:
-      paramDate = new Date(String(config.since));
-      if(paramDate === undefined){
-        config.since = 'always';
-      }else{
-        config.since = paramDate;
-      }
-  }
+    var justNow, thisPeriod, paramDate;
+    switch(options.since){
+        case 'tonight':
+            justNow = new Date();
+            thisPeriod = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate());
+            config.since = thisPeriod;
+            break;
+        case 'yesterday':
+            justNow = new Date();
+            thisPeriod = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-1);
+            config.since = thisPeriod;
+            break;
+        case 'lastweek':
+            justNow = new Date();
+            thisPeriod = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-7);
+            config.since = thisPeriod;
+            break;
+        case 'always':
+            break;
+        default:
+            paramDate = new Date(String(config.since));
+            if(paramDate === undefined){
+              config.since = 'always';
+            }else{
+              config.since = paramDate;
+            }
+    }
 }
 
 function mergeDefaultsWithArgs(config) {
@@ -276,7 +276,7 @@ function getBranchCommits(branchLatestCommit) {
             };
 
             if(commitData.date > config.since || config.since === 'always'){
-              commits.push(commitData);
+                commits.push(commitData);
             }
         });
 

--- a/index.js
+++ b/index.js
@@ -18,14 +18,13 @@ var config = {
     firstCommitAdditionInMinutes: 2 * 60,
 
     //Since data
-    since: '2015-01-01'
+    since: 'always'
 };
 
 function main() {
     parseArgs();
     config = mergeDefaultsWithArgs(config);
-
-    console.log(config.since);
+    parseSinceDate(config);
 
     commits('.').then(function(commits) {
         var commitsByEmail = _.groupBy(commits, function(commit) {
@@ -113,6 +112,35 @@ function parseArgs() {
     program.parse(process.argv);
 }
 
+function parseSinceDate(options){
+  switch(options.since){
+    case 'tonight':
+      var justNow = new Date();
+      var tonight = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate());
+      config.since = tonight;
+      break;
+    case 'yesterday':
+      var justNow = new Date();
+      var tonight = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-1);
+      config.since = tonight;
+      break;
+    case 'lastweek':
+      var justNow = new Date();
+      var lastweek = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-7);
+      config.since = lastweek;
+      break;
+    case 'always':
+      break;
+    default:
+      var paramDate = new Date(String(config.since));
+      if(paramDate === undefined){
+        config.since = 'always';
+      }else{
+        config.since = paramDate;
+      }
+  }
+}
+
 function mergeDefaultsWithArgs(config) {
     return {
         range: program.range,
@@ -168,7 +196,6 @@ function commits(gitPath) {
         .reduce(function(allCommits, branchCommits) {
             _.each(branchCommits, function(commit) {
                 allCommits.push(commit);
-                console.log(commit.date);
             });
 
             return allCommits;
@@ -239,8 +266,7 @@ function getBranchCommits(branchLatestCommit) {
                 author: author
             };
 
-            var sinceDate = new Date(config.since);
-            if(commitData.date > sinceDate){
+            if(commitData.date > config.since || config.since === 'always'){
               commits.push(commitData);
             }
         });

--- a/index.js
+++ b/index.js
@@ -121,26 +121,27 @@ function parseArgs() {
 }
 
 function parseSinceDate(options){
+  var justNow, thisPeriod, paramDate;
   switch(options.since){
     case 'tonight':
-      var justNow = new Date();
-      var tonight = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate());
-      config.since = tonight;
+      justNow = new Date();
+      thisPeriod = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate());
+      config.since = thisPeriod;
       break;
     case 'yesterday':
-      var justNow = new Date();
-      var tonight = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-1);
-      config.since = tonight;
+      justNow = new Date();
+      thisPeriod = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-1);
+      config.since = thisPeriod;
       break;
     case 'lastweek':
-      var justNow = new Date();
-      var lastweek = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-7);
-      config.since = lastweek;
+      justNow = new Date();
+      thisPeriod = new Date(justNow.getFullYear(), justNow.getMonth(), justNow.getUTCDate()-7);
+      config.since = thisPeriod;
       break;
     case 'always':
       break;
     default:
-      var paramDate = new Date(String(config.since));
+      paramDate = new Date(String(config.since));
       if(paramDate === undefined){
         config.since = 'always';
       }else{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-hours",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Estimate time spent on a git repository",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-hours",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "Estimate time spent on a git repository",
   "main": "index.js",
   "scripts": {

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -2,6 +2,8 @@ var _ = require('lodash');
 var assert = require("assert");
 var exec = require('child_process').exec;
 
+var totalHoursCount;
+
 describe('git-hours', function() {
 
     describe('cli', function() {
@@ -16,9 +18,58 @@ describe('git-hours', function() {
                 var work = JSON.parse(stdout);
                 assert.notEqual(work.total.hours.length, 0);
                 assert.notEqual(work.total.commits.length, 0);
-
+                totalHoursCount = work.total.hours;
                 done();
             });
         });
     });
+
+    describe('Since option', function(){
+      it('Should analyse since today', function(done) {
+        exec('node index.js --since today', function(err, stdout, stderr) {
+          assert.ifError(err);
+          var work = JSON.parse(stdout);
+          assert.strictEqual(typeof work.total.hours, 'number');
+          done();
+        });
+      });
+
+      it('Should analyse since yesterday', function(done) {
+        exec('node index.js --since yesterday', function(err, stdout, stderr) {
+          assert.ifError(err);
+          var work = JSON.parse(stdout);
+          assert.strictEqual(typeof work.total.hours, 'number');
+          done();
+        });
+      });
+
+      it('Should analyse since last week', function(done){
+        exec('node index.js --since lastweek', function(err, stdout, stderr) {
+          assert.ifError(err);
+          var work = JSON.parse(stdout);
+          assert.strictEqual(typeof work.total.hours, 'number');
+          done();
+        });
+      });
+
+      it('Should analyse since a specific date', function(done){
+        exec('node index.js --since 2015-01-01', function(err, stdout, stderr) {
+          assert.ifError(err);
+          var work = JSON.parse(stdout);
+          assert.notEqual(work.total.hours, 0);
+          done();
+        });
+      });
+
+      it('Should analyse as without param', function(done){
+        exec('node index.js --since always', function(err, stdout, stderr) {
+          assert.ifError(err);
+          var work = JSON.parse(stdout);
+          assert.equal(work.total.hours, totalHoursCount);
+          done();
+        });
+      });
+    });
+
+
 });

--- a/test/test-functional.js
+++ b/test/test-functional.js
@@ -25,50 +25,50 @@ describe('git-hours', function() {
     });
 
     describe('Since option', function(){
-      it('Should analyse since today', function(done) {
-        exec('node index.js --since today', function(err, stdout, stderr) {
-          assert.ifError(err);
-          var work = JSON.parse(stdout);
-          assert.strictEqual(typeof work.total.hours, 'number');
-          done();
+        it('Should analyse since today', function(done) {
+            exec('node index.js --since today', function(err, stdout, stderr) {
+                assert.ifError(err);
+                var work = JSON.parse(stdout);
+                assert.strictEqual(typeof work.total.hours, 'number');
+                done();
+            });
         });
-      });
 
-      it('Should analyse since yesterday', function(done) {
-        exec('node index.js --since yesterday', function(err, stdout, stderr) {
-          assert.ifError(err);
-          var work = JSON.parse(stdout);
-          assert.strictEqual(typeof work.total.hours, 'number');
-          done();
+        it('Should analyse since yesterday', function(done) {
+            exec('node index.js --since yesterday', function(err, stdout, stderr) {
+                assert.ifError(err);
+                var work = JSON.parse(stdout);
+                assert.strictEqual(typeof work.total.hours, 'number');
+                done();
+            });
         });
-      });
 
-      it('Should analyse since last week', function(done){
-        exec('node index.js --since lastweek', function(err, stdout, stderr) {
-          assert.ifError(err);
-          var work = JSON.parse(stdout);
-          assert.strictEqual(typeof work.total.hours, 'number');
-          done();
+        it('Should analyse since last week', function(done){
+            exec('node index.js --since lastweek', function(err, stdout, stderr) {
+                assert.ifError(err);
+                var work = JSON.parse(stdout);
+                assert.strictEqual(typeof work.total.hours, 'number');
+                done();
+            });
         });
-      });
 
-      it('Should analyse since a specific date', function(done){
-        exec('node index.js --since 2015-01-01', function(err, stdout, stderr) {
-          assert.ifError(err);
-          var work = JSON.parse(stdout);
-          assert.notEqual(work.total.hours, 0);
-          done();
+        it('Should analyse since a specific date', function(done){
+            exec('node index.js --since 2015-01-01', function(err, stdout, stderr) {
+                assert.ifError(err);
+                var work = JSON.parse(stdout);
+                assert.notEqual(work.total.hours, 0);
+                done();
+            });
         });
-      });
 
-      it('Should analyse as without param', function(done){
-        exec('node index.js --since always', function(err, stdout, stderr) {
-          assert.ifError(err);
-          var work = JSON.parse(stdout);
-          assert.equal(work.total.hours, totalHoursCount);
-          done();
+        it('Should analyse as without param', function(done){
+            exec('node index.js --since always', function(err, stdout, stderr) {
+                assert.ifError(err);
+                var work = JSON.parse(stdout);
+                assert.equal(work.total.hours, totalHoursCount);
+                done();
+            });
         });
-      });
     });
 
 


### PR DESCRIPTION
This changes add to users the possibility to query hours count since specific date. It is really useful to managers who check hours every day.

Usage:
```bash
$ git hours --since 2015-01-31
$ git hours --since yesterday
```