### PR TITLE
Update nodegit dependency and fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,8 @@ language: node_js
 node_js:
   - '0.12'
 sudo: false
+git:
+  depth: 1000000
 before_script:
   - npm install -g nodegit
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,9 @@ script:
 notifications:
   email:
   - kimmobrunfeldt+git-hours@gmail.com
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - libstdc++-4.9-dev

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "commander": "^2.2.0",
     "lodash": "^2.4.1",
     "moment": "^2.10.6",
-    "nodegit": "^0.4.1"
+    "nodegit": "^0.11.0"
   },
   "devDependencies": {
     "eslint": "^1.5.1",

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ var git = require('nodegit');
 var program = require('commander');
 var _ = require('lodash');
 var moment = require('moment');
+var fs = require('fs');
 
 var DATE_FORMAT = 'YYYY-MM-DD';
 
@@ -21,6 +22,8 @@ var config = {
 };
 
 function main() {
+    exitIfShallow();
+
     parseArgs();
     config = mergeDefaultsWithArgs(config);
     config.since = parseSinceDate(config.since);
@@ -59,6 +62,14 @@ function main() {
     }).catch(function(e) {
         console.error(e.stack);
     });
+}
+
+function exitIfShallow() {
+    if (fs.existsSync(".git/shallow")) {
+        console.log("Cannot analyze shallow copies!");
+        console.log("Please run git fetch --unshallow before continuing!");
+        process.exit(1);
+    }
 }
 
 function parseArgs() {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ var git = require('nodegit');
 var program = require('commander');
 var _ = require('lodash');
 var moment = require('moment');
-var exec = Promise.promisify(require('child_process').exec);
 
 var DATE_FORMAT = 'YYYY-MM-DD';
 
@@ -183,9 +182,12 @@ function estimateHours(dates) {
 function getCommits(gitPath) {
     return git.Repository.open(gitPath)
     .then(function(repo) {
-        var branchNames = getBranchNames(gitPath);
+        var allReferences = getAllReferences(repo);
 
-        return Promise.map(branchNames, function(branchName) {
+        return Promise.filter(allReferences, function(reference) {
+            return reference.match(/refs\/heads\/.*/);
+        })
+        .map(function(branchName) {
             return getBranchLatestCommit(repo, branchName);
         })
         .map(function(branchLatestCommit) {
@@ -209,21 +211,8 @@ function getCommits(gitPath) {
     });
 }
 
-function getBranchNames(gitPath) {
-    var cmd = "git branch --no-color | awk -F ' +' '! /\\(no branch\\)/ {print $2}'";
-    return new Promise(function(resolve, reject) {
-        exec(cmd, {cwd: gitPath}, function(err, stdout, stderr) {
-            if (err) {
-                reject(err);
-            }
-
-            resolve(stdout
-                    .split('\n')
-                    .filter(function(e) { return e; })  // Remove empty
-                    .map(function(str) { return str.trim(); })  // Trim whitespace
-            );
-        });
-    });
+function getAllReferences(repo) {
+    return repo.getReferenceNames(git.Reference.TYPE.LISTALL);
 }
 
 function getBranchLatestCommit(repo, branchName) {


### PR DESCRIPTION
The nodegit dependency previously used did not work with the latest nodejs. Updating to the latest available nodegit fixes relevant errors.

Fixes "Error: Cannot find module '../build/Debug/nodegit.node'"
Closes #15 
Closes #18 
Fixes errors when the repository is in detached HEAD state
Prints a proper error message if the current repository is a shallow copy.

I've tested git-hours on node v5.5.0 and everything seems to work ok.