### PR TITLE
Add Node.js 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,9 +16,12 @@ notifications:
   email:
   - kimmobrunfeldt+git-hours@gmail.com
 
+env:
+  - CXX=g++-4.8
+
 addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
     packages:
-      - libstdc++-4.9-dev
+      - g++-4.8

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
   - 0.12
   - 4
   - 5
+  - 6
 
 sudo: false
 git:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ From a person working 8 hours per day, it would take more than 3 years to build 
 
     $ npm install -g git-hours
 
-Has been tested and works with node 0.12, 4.x, 5.x versions. **Do not use node version
+Has been tested and works with node 0.12, 4.x, 5.x, 6.x versions. **Do not use node version
 below 0.12**.
 
 **NOTE:** If for some reason `git hours` won't work, try to `npm install -g nodegit`.

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "commander": "^2.2.0",
     "lodash": "^2.4.1",
     "moment": "^2.10.6",
-    "nodegit": "^0.11.0"
+    "nodegit": "^0.13.2"
   },
   "devDependencies": {
     "eslint": "^1.5.1",


### PR DESCRIPTION
It seems that the version of nodegit used is too old and doesn't support the latest version of Node.js.

Running it on v6.2.1 results in the following error message:

> Error: Cannot find module '../build/Debug/nodegit.node'

Bumping the version to the latest nodegit seems to fix this. I've also updated the README and configured Travis to test on Node 6 as well. Finally, I configured Travis to use a C++11 compliant compiler because otherwise the Node.js 4 test would fail to compile.

According to https://github.com/nodegit/nodegit/pull/1011 it seems that nodegit will stop supporting 0.12 and 5 at some point.