### PR TITLE
Node v7 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "commander": "^2.2.0",
     "lodash": "^2.4.1",
     "moment": "^2.10.6",
-    "nodegit": "^0.13.2"
+    "nodegit": "^0.16.0"
   },
   "devDependencies": {
     "eslint": "^1.5.1",


### PR DESCRIPTION
An update of the `nodegit` version seemed to have done the trick for me, otherwise it wouldn't compile the deps at all.

~~Testing for Node v7 in Travis would be cool, but so far it seems that [it is not yet available](https://docs.travis-ci.com/user/languages/javascript-with-nodejs#Available-Versions).~~ It now is.